### PR TITLE
Add a regression test and fix a stack confusion problem.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,6 +24,9 @@ jobs:
           # - '5.16.3.1'
           - '5.14.4.1'
     steps:
+      - name: ACTIONS_ALLOW_UNSECURE_COMMANDS
+        id: ACTIONS_ALLOW_UNSECURE_COMMANDS
+        run: echo 'ACTIONS_ALLOW_UNSECURE_COMMANDS=true' >> $GITHUB_ENV
       - name: Set git to use LF
         run: |
           git config --global core.autocrlf false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,38 +13,26 @@ jobs:
       fail-fast: true
       matrix:
         perl-version:
-          - '5.32.0.1'
-          # - '5.30.3.1'
-          # - '5.28.2.1'
-          # - '5.26.3.1'
-          # - '5.24.4.1'
-          # - '5.22.3.1'
-          # - '5.20.3.3'
-          # - '5.18.4.1'
-          # - '5.16.3.1'
-          - '5.14.4.1'
+          - '5.30'
+          # - '5.28'
+          # - '5.26'
+          # - '5.24'
+          # - '5.22'
+          # - '5.20'
+          # - '5.18'
+          # - '5.16'
+          - '5.14'
     steps:
-      - name: ACTIONS_ALLOW_UNSECURE_COMMANDS
-        id: ACTIONS_ALLOW_UNSECURE_COMMANDS
-        run: echo 'ACTIONS_ALLOW_UNSECURE_COMMANDS=true' >> $GITHUB_ENV
+      - name: Setup perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl-version }}
+          distribution: strawberry
       - name: Set git to use LF
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
       - uses: actions/checkout@v2
-      - name: Remove GH's Strawberry Perl and MinGW from Path
-        run: |
-          echo "::set-env name=PATH::$(($env:Path.split(";", [System.StringSplitOptions]::RemoveEmptyEntries) | where{-not ($_ -clike '*Strawberry*' -or $_ -clike '*mingw*')}) -join ';')"
-      - name: Add our new Strawberry Portable Perl Paths
-        run: |
-          Remove-Item C:\straw -Recurse -ErrorAction Ignore
-          mkdir C:\straw
-          echo "::add-path::C:\straw\c\bin;C:\straw\perl\site\bin;C:\straw\perl\bin"
-          echo $env:PATH
-      - name: Set up our new Strawberry Perl
-        run: |
-          Invoke-WebRequest -Uri https://strawberry.perl.bot/download/${{ matrix.perl-version }}/strawberry-perl-${{ matrix.perl-version }}-64bit-portable.zip -OutFile ${{matrix.perl-version}}.zip
-          7z x "${{matrix.perl-version}}.zip" -oC:\straw
       - name: perl -V
         run: perl -V
       - name: Ensure old Strawberries have a good toolchain

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Change history for HTML-Parser
 
 {{$NEXT}}
+  * Add a fix for a stack confusion error on `eof`. Thanks, Matthew Horsfall.
 
 3.75      2020-08-30
   * Cleanup the prereqs a bit

--- a/Parser.xs
+++ b/Parser.xs
@@ -436,7 +436,7 @@ eof(self)
             SPAGAIN;
             p_state->parsing = 0;
         }
-    PUSHs(self);
+        PUSHs(self);
 
 SV*
 strict_comment(pstate,...)

--- a/Parser.xs
+++ b/Parser.xs
@@ -424,18 +424,19 @@ parse(self, chunk)
 
 void
 eof(self)
-	SV* self;
+    SV* self;
     PREINIT:
-	PSTATE* p_state = get_pstate_hv(aTHX_ self);
+    PSTATE* p_state = get_pstate_hv(aTHX_ self);
     PPCODE:
         if (p_state->parsing)
             p_state->eof = 1;
         else {
-	    p_state->parsing = 1;
-	    parse(aTHX_ p_state, 0, self); /* flush */
-	    p_state->parsing = 0;
-	}
-	PUSHs(self);
+            p_state->parsing = 1;
+            parse(aTHX_ p_state, 0, self); /* flush */
+            SPAGAIN;
+            p_state->parsing = 0;
+        }
+    PUSHs(self);
 
 SV*
 strict_comment(pstate,...)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Actions Status](https://github.com/libwww-perl/html-parser/workflows/linux/badge.svg)](https://github.com/libwww-perl/html-parser/actions)
-[![Actions Status](https://github.com/libwww-perl/html-parser/workflows/macos/badge.svg)](https://github.com/libwww-perl/html-parser/actions)
-[![Actions Status](https://github.com/libwww-perl/html-parser/workflows/windows/badge.svg)](https://github.com/libwww-perl/html-parser/actions)
+[![Actions Status](https://github.com/libwww-perl/HTML-Parser/workflows/linux/badge.svg)](https://github.com/libwww-perl/HTML-Parser/actions)
+[![Actions Status](https://github.com/libwww-perl/HTML-Parser/workflows/macos/badge.svg)](https://github.com/libwww-perl/HTML-Parser/actions)
+[![Actions Status](https://github.com/libwww-perl/HTML-Parser/workflows/windows/badge.svg)](https://github.com/libwww-perl/HTML-Parser/actions)
 
 # NAME
 

--- a/t/stack-realloc-eof.t
+++ b/t/stack-realloc-eof.t
@@ -1,0 +1,198 @@
+use strict;
+use warnings;
+
+use HTML::Parser ();
+use Test::More tests => 2;
+
+# HTML-Parser core dumps on this because
+# of missing SPAGAIN calls in parse() XS code.  It was not prepared for
+# the stack to get realloced.
+
+my $em = <<'EOF';
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /></head><body style='font-size: 10pt; font-family: Verdana,Geneva,sans-serif'>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+<p><span style="font-size: 10.0pt; font-family: 'Verdana','sans-serif';">cat</span></p>
+</body></html>
+EOF
+
+sub handle_doc_end {
+    my ($self) = @_;
+
+    # We need to construct a large list and then splice it in array context, this will
+    # cause splice to regrow the stack and mess up the stack pointer in Parser.xs's eof
+    my @list;
+
+    for (1..150) {
+       push @list, 1; # { $_ => 1 };
+    }
+
+    # ok(1, 'splicing');
+
+    foreach my $i (splice(@list)) { }
+
+    # ok(1, 'done splicing');
+}
+
+sub extract {
+    my $markup = shift;
+
+    my $parser = HTML::Parser->new(
+        api_version => 3,
+        handlers => {
+            end_document => [\&handle_doc_end => 'self']
+        },
+    );
+    $parser->empty_element_tags(1);
+    $parser->parse($markup);
+    $parser->eof();
+    return 1;
+}
+
+ok(extract($em), 'first call okay');
+ok(extract($em), 'second call okay');


### PR DESCRIPTION
Parser.xs fails to call `SPAGAIN` after `parse` within `eof`.

Add a regression test so that this doesn't get reverted accidentally in the future.
Add a fix to the problem by calling `SPAGAIN` after `parse`.

Thank you, Matthew Horsfall (@wolfsage).
