### PR TITLE
Update tests to remove HTML4 specific tags

### DIFF
--- a/t/linkextor-base.t
+++ b/t/linkextor-base.t
@@ -14,7 +14,9 @@ $p->parse(<<HTML)->eof;
 <head>
 <base href="http://www.sn.no/">
 </head>
-<body background="http://www.sn.no/sn.gif">
+<body>
+<form action="/post_here">
+</form>
 
 This is <A HREF="link.html">link</a> and an <img SRC="img.jpg"
 lowsrc="img.gif" alt="Image">.


### PR DESCRIPTION
After https://github.com/petdance/html-tagset/issues/2 (v5 tag support) is released, HTML::Parser tests will fail, as we will default to v5 tags. This PR updates the tests to make them html-version neutral.