### PR TITLE
skip threads on older perl versions, as they often segfault

### DIFF
--- a/t/threads.t
+++ b/t/threads.t
@@ -8,6 +8,8 @@ use Test::More;
 # Verify thread safety.
 BEGIN {
     plan(skip_all => "Not configured for threads") unless $Config{useithreads};
+    plan(skip_all => "Threads are not reliable on older perls")
+        unless "$]" >= 5.010001;
     plan(tests    => 1);
 }
 use threads;


### PR DESCRIPTION
Threads are super unreliable on perls older than 5.10.1. They will cause
segfaults even for extremely trivial cases. Better to just skip the
threads tests on those perls.

Later 5.8 releases may be a bit more reliable, but 5.10.0 is
particularly bad. For simplicity, just cut it off at 5.10.1.