### PR TITLE
fix compatibility with ancient perl by avoiding index in test

### DIFF
--- a/t/parser.t
+++ b/t/parser.t
@@ -163,7 +163,7 @@ for my $chunksize (64 * 1024, 64, 13, 3, 1, "file", "filehandle") {
         "|>>body<<|\n\n|",
         )
     {
-        if (index($res, $_) < 0) {
+        if ($res !~ /\Q$_\E/) {
             diag "Can't find '$_' in parsed document";
             $bad++;
         }


### PR DESCRIPTION
Perl 5.8.5 and older have bugs in the index function that prevent it from matching a downgraded string to an upgraded string. Regex matches don't suffer from the same bug, so we can use them instead and be compatible with all relevant versions.