### PR TITLE
fix test scripts after conversion to Test::More

### DIFF
--- a/t/document.t
+++ b/t/document.t
@@ -11,30 +11,30 @@ my $p
 
 $events = "";
 $p->eof;
-ok($events, "start_document\nend_document\n");
+is($events, "start_document\nend_document\n");
 
 $events = "";
 $p->parse_file(File::Spec->devnull);
-ok($events, "start_document\nend_document\n");
+is($events, "start_document\nend_document\n");
 
 $events = "";
 $p->parse("");
 $p->eof;
-ok($events, "start_document\nend_document\n");
+is($events, "start_document\nend_document\n");
 
 $events = "";
 $p->parse("");
 $p->parse("");
 $p->eof;
-ok($events, "start_document\nend_document\n");
+is($events, "start_document\nend_document\n");
 
 $events = "";
 $p->parse("");
 $p->parse("<a>");
 $p->eof;
-ok($events, "start_document\nstart\nend_document\n");
+is($events, "start_document\nstart\nend_document\n");
 
 $events = "";
 $p->parse("<a> ");
 $p->eof;
-ok($events, "start_document\nstart\ntext\nend_document\n");
+is($events, "start_document\nstart\ntext\nend_document\n");

--- a/t/script.t
+++ b/t/script.t
@@ -29,7 +29,7 @@ $p->parse(
 );
 $p->eof;
 
-ok($TEXT, <<'EOT');
+is($TEXT, <<'EOT');
 [start_document,<undef>,]
 [start,tr,<tr>]
 [start,td,<td align="center" height="100">]


### PR DESCRIPTION
Two of the test scripts were converted from Test to Test::More, but their usage of ok was not properly updated. Test's ok works like ok, is, and like, depending on what arguments it is given. Fix the calls to use is so they are actually testing something.