### PR TITLE
"img lowsrc" and "body background" are not in the HTMLv5 spec

### DIFF
--- a/t/linkextor-base.t
+++ b/t/linkextor-base.t
@@ -3,7 +3,7 @@ use warnings;
 
 use HTML::LinkExtor ();
 use URI             ();
-use Test::More tests => 5;
+use Test::More tests => 4;
 
 # This test that HTML::LinkExtor really absolutize links correctly
 # when a base URL is given to the constructor.
@@ -19,7 +19,7 @@ $p->parse(<<HTML)->eof;
 </form>
 
 This is <A HREF="link.html">link</a> and an <img SRC="img.jpg"
-lowsrc="img.gif" alt="Image">.
+alt="Image">.
 HTML
 
 my @links = $p->links;
@@ -36,8 +36,6 @@ for (@links) {
 is($t, 'img');
 
 is(delete $attr{src}, "http://www.sn.no/foo/img.jpg");
-
-is(delete $attr{lowsrc}, "http://www.sn.no/foo/img.gif");
 
 # there should be no more attributes
 ok(!scalar(keys %attr));

--- a/t/linkextor-rel.t
+++ b/t/linkextor-rel.t
@@ -2,16 +2,16 @@ use strict;
 use warnings;
 
 use HTML::LinkExtor ();
-use Test::More tests => 4;
+use Test::More tests => 3;
 
 my $HTML = <<HTML;
 <head>
 <base href="http://www.sn.no/">
 </head>
-<body background="http://www.sn.no/sn.gif">
+<body>
 
 This is <A HREF="link.html">link</a> and an <img SRC="img.jpg"
-lowsrc="img.gif" alt="Image">.
+alt="Image">.
 HTML
 
 
@@ -26,7 +26,6 @@ my $p = HTML::LinkExtor->new(sub {
 $p->parse($HTML); $p->eof;
 
 ok($links =~ m|^base href http://www\.sn\.no/$|m);
-ok($links =~ m|^body background http://www\.sn\.no/sn\.gif$|m);
 ok($links =~ m|^a href link\.html$|m);
 
 # Used to be problems when using the links method on a document with


### PR DESCRIPTION
So that HTML::TagSet can default to v5, I have removed these from the tests