### PR TITLE
fix '$\/]' in HTML::Entities::encode_entities

### DIFF
--- a/lib/HTML/Entities.pm
+++ b/lib/HTML/Entities.pm
@@ -453,7 +453,24 @@ sub encode_entities
 	    #  [ (technically unnecessary but included for symmetry with ])
 	    #  ] (end of character class)
 	    #  \ (escape character)
-	    $chars =~ s{(\\.)|(['\[\]\\])}{ defined $1 ? $1 : '\\' . $2 }seg;
+	    $chars =~ s{
+	        # capture group 1: things to skip and keep
+	        (
+	            # any escaped character
+	            \\.
+	        |
+	            # either an actual POSIX character class or anything
+	            # similar enough to trigger a regex syntax error
+	            \[: \^? [[:lower:][:digit:]]{3,} :\]
+	        )
+	        |
+	        # capture group 2: things to be escaped
+	        (
+	            ['\[\]\\]
+	        )
+	    }{
+	        defined $1 ? $1 : '\\' . $2
+	    }xseg;
 
 	    my $code = "sub { \$_[0] =~ s'([$chars])'\$char2entity{\$1} || num_entity(\$1)'ge; }";
 	    $subst{$_[1]} = eval $code;

--- a/t/entities.t
+++ b/t/entities.t
@@ -3,7 +3,7 @@ use warnings;
 use utf8;
 
 use HTML::Entities qw(decode_entities encode_entities encode_entities_numeric);
-use Test::More tests => 24;
+use Test::More tests => 29;
 
 my $x = "V&aring;re norske tegn b&oslash;r &#230res";
 
@@ -39,6 +39,14 @@ is(encode_entities($x, '$'), '<]&#36;a/b\\c/d&#36;');
 is(encode_entities($x, '\\\\/'), '<]$a&#47;b&#92;c&#47;d$');
 is(encode_entities($x, '\\\\/$'), '<]&#36;a&#47;b&#92;c&#47;d&#36;');
 is(encode_entities($x, '<\\\\]'), '&lt;&#93;$a/b&#92;c/d$');
+
+# POSIX character classes
+$x = "<Våre123[=]";
+is(encode_entities($x, '[:punct:]'),          "&lt;Våre123&#91;&#61;&#93;");
+is(encode_entities($x, '^[:^digit:]'),        "<Våre&#49;&#50;&#51;[=]");
+is(encode_entities($x, '[:lower:][:digit:]'), "<V&aring;&#114;&#101;&#49;&#50;&#51;[=]");
+is(encode_entities($x, '=[:^ascii:]<>'),      "&lt;V&aring;re123[&#61;]");
+is(encode_entities($x, '[:Vlower:]'),         "<&#86;å&#114;&#101;123&#91;=&#93;");
 
 # See how well it does against rfc1866...
 my $ent   = '';

--- a/t/entities.t
+++ b/t/entities.t
@@ -3,7 +3,7 @@ use warnings;
 use utf8;
 
 use HTML::Entities qw(decode_entities encode_entities encode_entities_numeric);
-use Test::More tests => 20;
+use Test::More tests => 24;
 
 my $x = "V&aring;re norske tegn b&oslash;r &#230res";
 
@@ -32,6 +32,13 @@ is(encode_entities($x, '/'),   "[24&#47;7]\\");
 is(encode_entities($x, '\\/'), "[24&#47;7]\\");
 is(encode_entities($x, '\\'),  "[24/7]&#92;");
 is(encode_entities($x, ']\\'), "[24/7&#93;&#92;");
+
+# https://github.com/libwww-perl/HTML-Parser/issues/44
+$x = '<]$a/b\c/d$';
+is(encode_entities($x, '$'), '<]&#36;a/b\\c/d&#36;');
+is(encode_entities($x, '\\\\/'), '<]$a&#47;b&#92;c&#47;d$');
+is(encode_entities($x, '\\\\/$'), '<]&#36;a&#47;b&#92;c&#47;d&#36;');
+is(encode_entities($x, '<\\\\]'), '&lt;&#93;$a/b&#92;c/d$');
 
 # See how well it does against rfc1866...
 my $ent   = '';


### PR DESCRIPTION
encode_entities() generates and evals custom code at runtime (as a performance optimization). However, its code generation was too naive and certain characters could be used to break out of the character class regex:

 - `$` (dollar sign) would trigger perl's variable interpolation
 - `]` and `/` (the character class and regex delimiters, respectively)

The latter two were usually escaped, but not if they were preceded by `\` in the input, even if that `\` was itself escaped by another `\` (NB: this is why it is generally a mistake to handle escaping logic with look-behinds: you need arbitrary-width look-behind to figure out whether the current chain of backslashes is even or odd in length in order to know what is being escaped or not).

The latter issue was fixed by doing a single pass over the input string with no look-behind; the former by switching the delimiter to `'` (which inhibits interpolation).

Fixes #44.